### PR TITLE
Update accelerator_metrics

### DIFF
--- a/self-cert-questionnaire-template.yaml
+++ b/self-cert-questionnaire-template.yaml
@@ -9,7 +9,7 @@
 # Participants should fill in the 'status', 'evidence', and 'notes' fields for each requirement.
 
 metadata:
-  conformanceVersion: 0.1
+  conformanceVersion: 0.2
   kubernetesVersion: 1.34
   platformName: "[Platform Name]"
   platformVersion: "[Platform Version]"
@@ -52,7 +52,7 @@ spec:
       notes: ""
   observability:
     - id: accelerator_metrics
-      description: "For supported accelerator types, expose fine-grained performance metrics via a standardized, machine-readable format metrics endpoint. This must include a core set of metrics for per-accelerator utilization and memory usage. Additionally, other relevant metrics such as temperature, power draw, and interconnect bandwidth should be exposed if the underlying hardware or virtualization layer makes them available. The list of metrics should align with emerging standards, such as OpenTelemetry metrics, to ensure interoperability."
+      description: "For supported accelerator types, the platform must allow for the installation and successful operation of at least one accelerator metrics solution that exposes fine-grained performance metrics via a standardized, machine-readable metrics endpoint. This must include a core set of metrics for per-accelerator utilization and memory usage. Additionally, other relevant metrics such as temperature, power draw, and interconnect bandwidth should be exposed if the underlying hardware or virtualization layer makes them available. The list of metrics should align with emerging standards, such as OpenTelemetry metrics, to ensure interoperability. The platform may provide a managed solution, but this is not required for conformance."
       level: MUST
       status: ""
       evidence: ""


### PR DESCRIPTION
Per the [wg-ai-conformance 2025-09-11 meeting](https://docs.google.com/document/d/1qlW1LkibOoiMio-hbJucRjOYeKT8mNaQ4awwzf0bi8M/edit?tab=t.0#heading=h.7eifnx8ottq6), the group decided to update the description of the `accelerator_metrics` requirement with `The platform must allow for the installation and successful operation of at least one accelerator metrics solution…` to give vendors time to meet this requirement, with the intent to change this requirement to `The platform should support enabling accelerator metrics solutions` in a future version of the AI conformance profile.

@mfahlandt @castrojo @jeefy @janetkuo @terrytangyuan
